### PR TITLE
replace map with sync.Map as it fits cache, remove unnecessary memory…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Giulio2002/bls
 
-go 1.18
+go 1.23
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
1. Instead of using `map`, using sync.Map might be better choice in here. From it's documentation:

**"The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys"**

The first (1) is our case and as it's optimised I think using that map would be better. On top of that we won't need any mutex as it's already thread safe data structure.


2. I removed unnecessary memory copying into `publicKeySharedBuffer`, Maybe I'm missing something but we don't really need that.


3. It could be part of a separate PR but wanted to upgrade go version (`map.Clear()` isn't there below `1.23`). 